### PR TITLE
fix: increase health check failure threshold

### DIFF
--- a/charts/friendly-computing-machine/templates/deployment.yaml
+++ b/charts/friendly-computing-machine/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             port: health
           initialDelaySeconds: 5
           periodSeconds: 10
-          failureThreshold: 5
+          failureThreshold: 10
         {{- end }}
         args:
           - bot


### PR DESCRIPTION
This pull request includes a change to the `charts/friendly-computing-machine/templates/deployment.yaml` file. The change modifies the `failureThreshold` value in the health check configuration.

* [`charts/friendly-computing-machine/templates/deployment.yaml`](diffhunk://#diff-700306068b05202410169ff2b8bbcd6ab98dfc5b68791060dd2c1152373af867L76-R76): Increased the `failureThreshold` from 5 to 10 to allow for more retries before considering a failure.