### PR TITLE
feat: add team Slack ID handling in message creation

### DIFF
--- a/src/friendly_computing_machine/bot/task/musicpoll.py
+++ b/src/friendly_computing_machine/bot/task/musicpoll.py
@@ -215,6 +215,7 @@ class MusicPollArchiveMessages(AbstractTask):
                     msg,
                     # specify because we pulled it down and I don't think it's included in the response
                     slack_channel_slack_id=slack_channel_slack_id,
+                    team_slack_id=slack_client.team_id,
                 )
                 # this is too much info but was useful for debug, although not useful enough
                 # logger.info('upserting message %s %s %s', create.slack_id, create.ts, create.text)

--- a/src/friendly_computing_machine/models/slack.py
+++ b/src/friendly_computing_machine/models/slack.py
@@ -87,15 +87,21 @@ class SlackMessage(SlackMessageBase, table=True):
 class SlackMessageCreate(SlackMessageBase):
     @classmethod
     def from_slack_message_json(
-        cls, message_event: Dict[str, Any], slack_channel_slack_id: Optional[str] = None
+        cls,
+        message_event: Dict[str, Any],
+        slack_channel_slack_id: Optional[str] = None,
+        team_slack_id: Optional[str] = None,
     ) -> "SlackMessageCreate":
         thread_ts = message_event.get("thread_ts")
         channel_id = message_event.get("channel", slack_channel_slack_id)
         if channel_id is None:
             raise ValueError("channel_id cannot be None")
+        team_id = message_event.get("team") or team_slack_id
+        if team_id is None:
+            raise ValueError("team_id cannot be None")
         message = SlackMessageCreate(
             slack_id=message_event.get("client_msg_id"),
-            slack_team_slack_id=message_event.get("team"),
+            slack_team_slack_id=team_id,
             slack_channel_slack_id=channel_id,
             slack_user_slack_id=message_event.get("user"),
             text=message_event.get("text"),


### PR DESCRIPTION
This pull request includes changes to handle the `team_slack_id` in the `archive_message_batch` function and the `SlackMessageCreate` class. These changes ensure that the `team_slack_id` is properly managed and validated.

Improvements to `archive_message_batch` function:

* Added `team_slack_id` parameter to the `archive_message_batch` function to ensure it is included in the message archiving process. (`src/friendly_computing_machine/bot/task/musicpoll.py`)

Enhancements to `SlackMessageCreate` class:

* Updated the `from_slack_message_json` method to include an optional `team_slack_id` parameter and added validation to ensure `team_id` is not `None`. (`src/friendly_computing_machine/models/slack.py`)
* Modified the creation of `SlackMessageCreate` instances to use the validated `team_id` for the `slack_team_slack_id` attribute. (`src/friendly_computing_machine/models/slack.py`)