### PR TITLE
fix: fix docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,5 +52,5 @@ ENV UV_COMPILE_BYTECODE=0
 
 RUN uv run opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 
-ENTRYPOINT ["uv", "run", "fcm"]
-#ENTRYPOINT ["uv", "run", "opentelemetry-instrument", "fcm"]
+#ENTRYPOINT ["uv", "run", "fcm"]
+ENTRYPOINT ["uv", "run", "opentelemetry-instrument", "fcm"]


### PR DESCRIPTION
yeah I done goof


AI summary is longer than the code change


---

This pull request modifies the `ENTRYPOINT` in the `Dockerfile` to change how the application is executed. The change switches from running the application directly to running it with OpenTelemetry instrumentation enabled.

Key change:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L55-R56): Updated the `ENTRYPOINT` to use `opentelemetry-instrument`, enabling OpenTelemetry instrumentation for the `fcm` application. This replaces the previous configuration where the application was run directly.