### PR TITLE
fix: rename and update slack tagging activity for improved functionality

### DIFF
--- a/src/friendly_computing_machine/temporal/slack/activity.py
+++ b/src/friendly_computing_machine/temporal/slack/activity.py
@@ -106,8 +106,9 @@ async def backfill_slack_user_info_activity() -> list[SlackUserCreate]:
 @activity.defn
 async def fix_slack_tagging_activity(text: str) -> str:
     """
-    Prepare the prompt for the Gemini AI model.
-    This function can be used to modify or format the prompt before sending it to the model.
+    Fix slack tagging in the text.
+    This function replaces @here and @channel with their escaped versions.
+    TODO: It also replaces <@U12345> with @U12345.
     """
 
     # TODO - person name replacement

--- a/src/friendly_computing_machine/temporal/slack/activity.py
+++ b/src/friendly_computing_machine/temporal/slack/activity.py
@@ -104,7 +104,7 @@ async def backfill_slack_user_info_activity() -> list[SlackUserCreate]:
 
 
 @activity.defn
-async def prepare_prompt_for_slack_activity(prompt: str) -> str:
+async def fix_slack_tagging_activity(text: str) -> str:
     """
     Prepare the prompt for the Gemini AI model.
     This function can be used to modify or format the prompt before sending it to the model.
@@ -113,7 +113,7 @@ async def prepare_prompt_for_slack_activity(prompt: str) -> str:
     # TODO - person name replacement
 
     # Replace @here and @channel with their escaped versions only if not already escaped
-    prompt = re.sub(r"(?<!<)@here", "<!here>", prompt)
-    prompt = re.sub(r"(?<!<)@channel", "<!channel>", prompt)
+    text = re.sub(r"(?<!<)@here", "<!here>", text)
+    text = re.sub(r"(?<!<)@channel", "<!channel>", text)
 
-    return prompt
+    return text

--- a/src/friendly_computing_machine/temporal/slack/workflow.py
+++ b/src/friendly_computing_machine/temporal/slack/workflow.py
@@ -25,9 +25,9 @@ from friendly_computing_machine.temporal.db.job_activity import (
 from friendly_computing_machine.temporal.slack.activity import (
     GenerateContextPromptParams,
     backfill_slack_user_info_activity,
+    fix_slack_tagging_activity,
     generate_context_prompt,
     get_slack_channel_context,
-    prepare_prompt_for_slack_activity,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,46 +57,47 @@ class SlackContextGeminiWorkflow:
         slack_prompts = await workflow.execute_activity(
             get_slack_channel_context,
             params.slack_channel_slack_id,
-            schedule_to_close_timeout=timedelta(seconds=60),
-            start_to_close_timeout=timedelta(seconds=60),
+            schedule_to_close_timeout=timedelta(seconds=5),
+            start_to_close_timeout=timedelta(seconds=5),
         )
         summary_future = workflow.execute_activity(
             generate_summary,
             slack_prompts,
-            schedule_to_close_timeout=timedelta(seconds=60),
-            start_to_close_timeout=timedelta(seconds=60),
+            schedule_to_close_timeout=timedelta(seconds=10),
+            start_to_close_timeout=timedelta(seconds=10),
         )
         vibe_future = workflow.execute_activity(
             get_vibe,
             params.prompt,
             start_to_close_timeout=timedelta(seconds=10),
         )
-        prompt_future = workflow.execute_activity(
-            prepare_prompt_for_slack_activity,
-            params.prompt,
-            start_to_close_timeout=timedelta(seconds=10),
-        )
 
-        vibe, summary, prepared_prompt = await asyncio.gather(
-            vibe_future, summary_future, prompt_future
-        )
+        vibe, summary = await asyncio.gather(vibe_future, summary_future)
 
         # this is a hack to do something I don't know how to do
         # and doesn't really work, but it's at least a start
         # TODO - understand context
         context_prompt = await workflow.execute_activity(
             generate_context_prompt,
-            GenerateContextPromptParams(prepared_prompt, summary, vibe),
-            schedule_to_close_timeout=timedelta(seconds=60),
-            start_to_close_timeout=timedelta(seconds=60),
+            GenerateContextPromptParams(params.prompt, summary, vibe),
+            schedule_to_close_timeout=timedelta(seconds=10),
+            start_to_close_timeout=timedelta(seconds=10),
         )
         response = await workflow.execute_activity(
             generate_gemini_response,
             context_prompt,
-            schedule_to_close_timeout=timedelta(seconds=60),
-            start_to_close_timeout=timedelta(seconds=60),
+            schedule_to_close_timeout=timedelta(seconds=10),
+            start_to_close_timeout=timedelta(seconds=10),
         )
-        return response
+
+        tagged_response = await workflow.execute_activity(
+            fix_slack_tagging_activity,
+            response,
+            schedule_to_close_timeout=timedelta(seconds=5),
+            start_to_close_timeout=timedelta(seconds=5),
+        )
+
+        return tagged_response
 
 
 @dataclass

--- a/src/friendly_computing_machine/temporal/worker.py
+++ b/src/friendly_computing_machine/temporal/worker.py
@@ -31,9 +31,9 @@ from friendly_computing_machine.temporal.sample import (
 )
 from friendly_computing_machine.temporal.slack.activity import (
     backfill_slack_user_info_activity,
+    fix_slack_tagging_activity,
     generate_context_prompt,
     get_slack_channel_context,
-    prepare_prompt_for_slack_activity,
 )
 from friendly_computing_machine.temporal.slack.workflow import (
     SlackContextGeminiWorkflow,
@@ -71,7 +71,7 @@ ACTIVITIES = [
     upsert_slack_user_creates_activity,
     backfill_genai_text_slack_user_id_activity,
     backfill_genai_text_slack_channel_id_activity,
-    prepare_prompt_for_slack_activity,
+    fix_slack_tagging_activity,
 ]
 
 


### PR DESCRIPTION
Less parallel, more correct

---

This pull request refactors the Slack-related activities and workflows to improve functionality and reduce redundancy. The key changes include replacing the `prepare_prompt_for_slack_activity` function with `fix_slack_tagging_activity`, updating timeout values for workflow activities, and ensuring proper Slack tagging in generated responses.

### Refactoring and Functionality Improvements:
* Replaced `prepare_prompt_for_slack_activity` with `fix_slack_tagging_activity` in `src/friendly_computing_machine/temporal/slack/activity.py`. The new function focuses on fixing Slack tagging issues by escaping `@here` and `@channel` mentions and includes a TODO to handle user mentions like `<@U12345>`.
* Updated all references to `prepare_prompt_for_slack_activity` with `fix_slack_tagging_activity` in `src/friendly_computing_machine/temporal/slack/workflow.py` and `src/friendly_computing_machine/temporal/worker.py`. [[1]](diffhunk://#diff-79f0b13c85604c51d8f4ed06769cbf4c80c602487f97ba57a0779db4c2702db3R28-L30) [[2]](diffhunk://#diff-368d424beca2c65b293718e6aacbf8158a792eff7c9653e4ae76f5d54a350420R34-L36) [[3]](diffhunk://#diff-368d424beca2c65b293718e6aacbf8158a792eff7c9653e4ae76f5d54a350420L74-R74)

### Workflow Enhancements:
* Adjusted timeout values for various workflow activities in `src/friendly_computing_machine/temporal/slack/workflow.py` to optimize execution time:
  - Reduced `schedule_to_close_timeout` and `start_to_close_timeout` for `get_slack_channel_context` from 60 seconds to 5 seconds.
  - Reduced the same timeouts for `generate_summary` and `generate_context_prompt` from 60 seconds to 10 seconds.
* Added a new step in the workflow to call `fix_slack_tagging_activity` on the generated response, ensuring proper tagging before returning the final result.